### PR TITLE
Allow load files at startup

### DIFF
--- a/Telemetry Viewer/src/Main.java
+++ b/Telemetry Viewer/src/Main.java
@@ -115,6 +115,9 @@ public class Main {
 			}
 		});
 		
+		// allow load settings/CSV/camera files at startup
+		if (args.length>0) ConnectionsController.importFiles(args);
+		
 		// handle window close events
 		window.addWindowListener(new WindowAdapter() {
 			@Override public void windowClosing(java.awt.event.WindowEvent windowEvent) {


### PR DESCRIPTION
Allow load settings/CSV/camera files at startup through command line arguments. 

Specify file names that will be loaded automatically into working area:

`java --illegal-access=permit -jar TelemetryViewer.jar settings.txt`

Also this feature speed ups development as you don't have to drag and drop setting files info fresh started program.